### PR TITLE
Fix typo breaking scroll wheel breath dual effect

### DIFF
--- a/src/libopenrazer/libopenrazer.cpp
+++ b/src/libopenrazer/libopenrazer.cpp
@@ -1796,7 +1796,7 @@ bool Device::setScrollBreathSingle(QColor color)
  */
 bool Device::setScrollBreathDual(QColor color, QColor color2)
 {
-    QDBusMessage m = prepareDeviceQDBusMessage("razer.device.lighting.scroll", "setScrollBreathSingle");
+    QDBusMessage m = prepareDeviceQDBusMessage("razer.device.lighting.scroll", "setScrollBreathDual");
     QList<QVariant> args;
     args.append(color.red());
     args.append(color.green());


### PR DESCRIPTION
I could not set the scroll wheel breath dual effect on my Lancehead TE, and saw no events in the openrazer-daemon logs.  Turns out it was a small typo:

`bool Device::setScrollBreathDual(QColor color, QColor color2)`

was creating a QBusMessage with:

`QDBusMessage m = prepareDeviceQDBusMessage("razer.device.lighting.scroll", "setScrollBreathSingle");`

Changed it to:

`QDBusMessage m = prepareDeviceQDBusMessage("razer.device.lighting.scroll", "setScrollBreathDual");`

Scroll wheel breath dual effect can now be correctly set :)