### PR TITLE
Fix ninja build error when include_matrix_discovery is enabled

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,18 +3,18 @@ project('razergenie', 'cpp',
         meson_version : '>=0.44.0',
         default_options : ['cpp_std=c++11'])
 
-qt5 = import('qt5')
-qt5_dep = dependency('qt5', modules: ['Core', 'DBus', 'Gui', 'Network', 'Widgets'])
-
-razer_test_dep = dependency('razer_test', fallback : ['razer_test', 'razer_test_dep'])
-libopenrazer_dep = dependency('libopenrazer', fallback : ['libopenrazer', 'libopenrazer_dep'])
-
 if get_option('include_matrix_discovery')
   add_global_arguments('-DINCLUDE_MATRIX_DISCOVERY', language : 'cpp')
   message('razergenie: Matrix discovery feature included.')
 else
   message('razergenie: Matrix discovery feature not included.')
 endif
+
+qt5 = import('qt5')
+qt5_dep = dependency('qt5', modules: ['Core', 'DBus', 'Gui', 'Network', 'Widgets'])
+
+razer_test_dep = dependency('razer_test', fallback : ['razer_test', 'razer_test_dep'])
+libopenrazer_dep = dependency('libopenrazer', fallback : ['libopenrazer', 'libopenrazer_dep'])
 
 install_data('logo/xyz.z3ntu.razergenie.svg', install_dir : join_paths(get_option('datadir'), 'icons/hicolor/scalable/apps'))
 


### PR DESCRIPTION
meson.build:13:2: ERROR: Tried to use 'add_global_arguments' after a build target has been declared.