### PR TITLE
Fix possible DPI stage inconsistencies

### DIFF
--- a/src/devicewidget/dpisliderwidget.cpp
+++ b/src/devicewidget/dpisliderwidget.cpp
@@ -135,9 +135,8 @@ DpiSliderWidget::DpiSliderWidget(QWidget *parent, libopenrazer::Device *device)
                     }
                 } else {
                     /* If the currently active stage was disabled, we need to
-                     * find a new one to enable */
+                     * let the UI know */
                     if (dpi.dpi_x == 0 && dpi.dpi_y == 0 && stageNumber == activeStage) {
-                        activeStage = 1;
                         for (DpiStageWidget *widget : dpiStageWidgets) {
                             widget->informStageActive(activeStage);
                         }
@@ -204,6 +203,18 @@ void DpiSliderWidget::handleStageUpdates()
         if (stageWidget->setStageNumber(stageNumber)) {
             stageNumber++;
         }
+    }
+
+    int maxStage = stageNumber - 1;
+
+    /* If activeStage is now out of bounds, we need to find a new one to enable */
+    if (activeStage > maxStage) {
+        activeStage = maxStage;
+    }
+
+    /* Make sure to update the UI for the currently active stage */
+    for (DpiStageWidget *widget : dpiStageWidgets) {
+        widget->informStageActive(activeStage);
     }
 
     /* Disable "Enable" button if last stage active */


### PR DESCRIPTION
If we have stage 1, 2 & 3 enabled. The selected stage is 3, and deactivate stage 2. Before we'd keep active_stage=3 while only sending two stages which is quite wrong, and even rejected by the driver.

Make sure to handle a stage that went out of bounds and make sure to update the UI accordingly.

There is however now behavior which I don't find super desirable:

  1 (enabled) x (disabled) 2 (enabled)

  We have stage 2 active
  We re-enable the middle one
  We now have still '2' active but we should've switched to '3' active
  since 2 is now the middle one and 3 is the right one

But hopefully it's obscure enough not too be distracting, since it doesn't seem to be super trivial to fix with the current design.

Fixes #183
Fixes #187